### PR TITLE
fix(SwalDirective): stop propagation of click event to parent handlers

### DIFF
--- a/src/swal.directive.ts
+++ b/src/swal.directive.ts
@@ -33,6 +33,7 @@ export class SwalDirective {
     public onHostClicked(event: MouseEvent): void {
         event.preventDefault();
         event.stopImmediatePropagation();
+        event.stopPropagation();
 
         const options = { ...this.defaultSwalOptions, ...this.modalOptions };
 


### PR DESCRIPTION
This fixes this case:

```
<tr [routerLink]="foo">
  <td>
    <a [swal]="swalOptions">Bar</a>
  <td>
</tr>
```

Where clicking on the `a` link triggered the swal but also triggered the `tr` *routerLink*.